### PR TITLE
Fix shebang in init script

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # Uruchom na początku, aby zbudować kontener (środowisko uruchomieniowe)
 


### PR DESCRIPTION
## Summary
- correct the shebang in `init.sh`
- keep the script executable

## Testing
- `bash -n init.sh`
- `bash -n process_invoices.sh`


------
https://chatgpt.com/codex/tasks/task_e_6854824fa2d08328959594ca5988774d