### PR TITLE
Add changelog and move TODO to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,18 @@ docker compose exec php php kontrahent.php <BAZA> <NIP>
 ## Licencja
 
 Projekt udostępniany jest na licencji MIT. Szczegóły w pliku `LICENSE`.
+
+## ToDo
+
+1. DONE - Obsługa faktur walutowych (do weryfikacji)
+2. DONE - Tworzenie kontrahentów i ich aktualizacja(?)
+3. Aktualizacja danych na fakturach w fakturowni (zapisanie w optimie id faktury i pozycji), zabezpieczenie, aby nie modyfikować już rozliczonych faktur (niebieskie w Optimie). Pole VaN_DekID wiąże fakturę z CDN.DekretyNag i jeżeli istnieje powiązane,
+   to należy taką fakturę pozostawić już w spokoju (integrator nie powinien jej dotykać)
+4. Przypisywanie kategorii (VaN_KatID, VaN_Kategoria)
+5. Obsługa faktur korygujących (VaN_DokumentyNadrzedne, VaN_KorektaDo, VaN_Korekta)
+
+## Changelog
+
+### 0.1
+
+- pierwsza publiczna wersja integratora

--- a/scripts/faktura.php
+++ b/scripts/faktura.php
@@ -396,13 +396,3 @@ try {
 
 
 
-/**
- * ToDo:
- * 1. DONE - Obsługa faktur walutowych (do weryfikacji)
- * 2. DONE - Tworzenie kontrahentów i ich aktualizacja(?)
- * 3. Aktualizacja danych na fakturach w fakturowni (zapisanie w optimie id faktury i pozycji), zabezpieczenie, aby nie modyfikować 
- *    już rozliczonych faktur (niebieskie w Optimie). Pole VaN_DekID wiąże fakturę z CDN.DekretyNag i jeżeli istnieje powiązane,
- *    to należy taką fakturę pozostawić już w spokoju (integrator nie powinien jej dotykać)
- * 4. Przypisywanie kategorii (VaN_KatID, VaN_Kategoria)
- * 5. Obsługa faktur korygujących (VaN_DokumentyNadrzedne, VaN_KorektaDo, VaN_Korekta)
- */


### PR DESCRIPTION
## Summary
- move TODO note from `faktura.php` into README
- add initial changelog section starting with version 0.1

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685489127a408328b1b093795798b132