### PR TITLE
Rename dbg.php and document helper functions

### DIFF
--- a/scripts/lib/helpers.php
+++ b/scripts/lib/helpers.php
@@ -38,6 +38,14 @@ function dbg(mixed $val)
     return $val;
 }
 
+/**
+ * Dopisuje identyfikator do pliku, jeśli nie występuje w nim jeszcze.
+ *
+ *  • plik jest tworzony automatycznie, gdy brak
+ *  • operacja blokuje plik na czas zapisu
+ *
+ * @throws RuntimeException gdy nie można otworzyć pliku
+ */
 function appendIdIfNew(string $path, string|int $id): void
 {
     // 'c+'  ➜   otwórz do R/W, utwórz plik jeśli nie istnieje
@@ -80,7 +88,7 @@ function appendIdIfNew(string $path, string|int $id): void
  * Akceptuje:
  *   DK37538795   DK 37538795   37538795
  *
- * @throws InvalidArgumentException – gdy format nie pasuje
+ * Zwraca tablicę z pustymi wartościami, jeśli numer ma zły format.
  */
 function splitVatId(string $raw): array
 {

--- a/scripts/lib/init.php
+++ b/scripts/lib/init.php
@@ -1,7 +1,7 @@
 <?php
 
 require  'Medoo.php';
-require  'dbg.php';
+require  'helpers.php';
 use Medoo\Medoo;
 
 $domain   = getenv('FAKTUROWNIA_DOMAIN')      ?: '';


### PR DESCRIPTION
## Summary
- rename `scripts/lib/dbg.php` to `helpers.php`
- update include path
- document helper functions
- correct splitVatId description

## Testing
- `git diff --staged --stat`


------
https://chatgpt.com/codex/tasks/task_e_68548abee51083289f3420fd2018cdb6