### PR TITLE
Run composer install during init

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -4,3 +4,8 @@
 
 docker compose build
 docker compose up -d
+
+# Install dependencies inside the PHP container if they are not present
+if [ ! -d scripts/vendor ]; then
+    docker compose exec php composer install
+fi


### PR DESCRIPTION
## Summary
- ensure PHP dependencies are installed when starting the container

## Testing
- `bash -n init.sh`

------
https://chatgpt.com/codex/tasks/task_e_68548fae67608328a9c0c85b76aaac08