### PR TITLE
Enable MSSQL schema names with custom Medoo subclass

### DIFF
--- a/scripts/lib/MedooMssql.php
+++ b/scripts/lib/MedooMssql.php
@@ -1,0 +1,13 @@
+<?php
+namespace Integrator;
+
+class MedooMssql extends \Medoo\Medoo
+{
+    /**
+     * Override table quoting to support schema-prefixed tables in MSSQL.
+     */
+    public function tableQuote(string $table): string
+    {
+        return $this->prefix . $table;
+    }
+}

--- a/scripts/lib/init.php
+++ b/scripts/lib/init.php
@@ -2,7 +2,9 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 require 'helpers.php';
+require 'MedooMssql.php';
 use Medoo\Medoo;
+use Integrator\MedooMssql;
 
 $domain   = getenv('FAKTUROWNIA_DOMAIN')      ?: '';
 $apiToken = getenv('FAKTUROWNIA_API_TOKEN')   ?: '';
@@ -30,7 +32,7 @@ $dbMySql = new Medoo([
     'type' => 'mysql'
 ]);
 
-$dbSqlServer = new Medoo([
+$dbSqlServer = new MedooMssql([
     'pdo' => new PDO($optDsn,  $optUsr,  $optPwd, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]),
     'type' => 'mssql'
 ]);


### PR DESCRIPTION
## Summary
- allow MSSQL table names with schema prefixes by overriding `tableQuote`
- load the new subclass in `init.php` and use it for the SQL Server connection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854981810e48328b943c1052333009d