### PR TITLE
Handle UID/GID defaults in init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ Integrator pobiera dane z Fakturowni i zapisuje je do bazy Comarch ERP Optima. �
    - `OPTIMADB_DSN`, `OPTIMADB_USER`, `OPTIMADB_PASS` – dane do połączenia z bazą Optimy
    - ścieżki do plików `companies.json`, `invoices.txt`, `customers.txt`
 2. Uruchom `./init.sh`, który zbuduje kontener,
-   zainstaluje zależności PHP i uruchomi środowisko:
+   zainstaluje zależności PHP i uruchomi środowisko. Skrypt
+   automatycznie eksportuje zmienne `UID` i `GID`, aby pliki
+   tworzone w kontenerze miały tego samego właściciela co na
+   hoście (można je nadpisać przed uruchomieniem):
 
 ```bash
 ./init.sh

--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Ensure Docker Compose has information about the invoking user
+export UID=${UID:-$(id -u)}
+export GID=${GID:-$(id -g)}
+
 # Uruchom na początku, aby zbudować kontener (środowisko uruchomieniowe)
 # oraz zainstalować zależności PHP
 


### PR DESCRIPTION
## Summary
- ensure `init.sh` sets default UID and GID so docker compose works with file permissions
- document the UID/GID export behaviour in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687231b0157483288c215853daa77147